### PR TITLE
fix: browser->circuit->browser discovery upon 3.0.0 upgrade

### DIFF
--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -108,7 +108,9 @@ export class DRPNetworkNode {
 		this._node = await createLibp2p({
 			privateKey,
 			addresses: {
-				listen: this._config?.addresses ? this._config.addresses : ["/webrtc", "/p2p-circuit"],
+				listen: this._config?.addresses
+					? this._config.addresses
+					: ["/webrtc", "/p2p-circuit"],
 			},
 			connectionEncrypters: [noise()],
 			connectionGater: {

--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -108,7 +108,7 @@ export class DRPNetworkNode {
 		this._node = await createLibp2p({
 			privateKey,
 			addresses: {
-				listen: this._config?.addresses ? this._config.addresses : ["/webrtc"],
+				listen: this._config?.addresses ? this._config.addresses : ["/webrtc", "/p2p-circuit"],
 			},
 			connectionEncrypters: [noise()],
 			connectionGater: {


### PR DESCRIPTION
Since the we upgraded circuit-relay-v2 to v3 we now need to also add /p2p-circuit into the listen cf: https://github.com/libp2p/js-libp2p/releases/tag/circuit-relay-v2-v3.0.0 breaking change