### PR TITLE
fix: deep cloning state and original drp

### DIFF
--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -27,7 +27,8 @@
 	"devDependencies": {
 		"@bufbuild/protobuf": "^2.0.0",
 		"benchmark": "^2.1.4",
-		"tsx": "4.19.1"
+		"tsx": "4.19.1",
+		"es-toolkit": "1.30.1"
 	},
 	"dependencies": {
 		"@ts-drp/logger": "^0.4.4"

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -13,7 +13,7 @@ import { ObjectSet } from "./utils/objectSet.js";
 
 export * as ObjectPb from "./proto/drp/object/v1/object_pb.js";
 export * from "./hashgraph/index.js";
-import { clone, cloneDeep } from "es-toolkit";
+import { cloneDeep } from "es-toolkit";
 
 export interface IACL {
 	isWriter: (peerId: string) => boolean;

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -13,6 +13,7 @@ import { ObjectSet } from "./utils/objectSet.js";
 
 export * as ObjectPb from "./proto/drp/object/v1/object_pb.js";
 export * from "./hashgraph/index.js";
+import { clone, cloneDeep } from "es-toolkit";
 
 export interface IACL {
 	isWriter: (peerId: string) => boolean;
@@ -96,10 +97,7 @@ export class DRPObject implements IDRPObject {
 		);
 		this.subscriptions = [];
 		this.states = new Map([[HashGraph.rootHash, { state: new Map() }]]);
-		this.originalDRP = Object.create(
-			Object.getPrototypeOf(drp),
-			Object.getOwnPropertyDescriptors(structuredClone(drp)),
-		);
+		this.originalDRP = cloneDeep(drp);
 		this.vertices = this.hashGraph.getAllVertices();
 	}
 
@@ -202,17 +200,14 @@ export class DRPObject implements IDRPObject {
 				? []
 				: this.hashGraph.linearizeOperations(lca, subgraph);
 
-		const drp = Object.create(
-			Object.getPrototypeOf(this.originalDRP),
-			Object.getOwnPropertyDescriptors(structuredClone(this.originalDRP)),
-		) as DRP;
+		const drp = cloneDeep(this.originalDRP);
 
 		const fetchedState = this.states.get(lca);
 		if (!fetchedState) {
 			throw new Error("State is undefined");
 		}
 
-		const state = structuredClone(fetchedState);
+		const state = cloneDeep(fetchedState);
 
 		for (const [key, value] of state.state) {
 			drp[key] = value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
+      es-toolkit:
+        specifier: 1.30.1
+        version: 1.30.1
       tsx:
         specifier: 4.19.1
         version: 4.19.1
@@ -2782,6 +2785,9 @@ packages:
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.30.1:
+    resolution: {integrity: sha512-ZXflqanzH8BpHkDhFa10bBf6ONDCe84EPUm7SSICGzuuROSluT2ynTPtwn9PcRelMtorCRozSknI/U0MNYp0Uw==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -8046,6 +8052,8 @@ snapshots:
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.30.1: {}
 
   esbuild@0.21.5:
     optionalDependencies:


### PR DESCRIPTION
Introduce using `cloneDeep` from `es-toolkit` to deeply clone nested objects with all functions, which makes canvas example work again and closes #293 