### PR TITLE
feat: check writer permission before merging

### DIFF
--- a/packages/blueprints/src/AddWinsSetWithACL/index.ts
+++ b/packages/blueprints/src/AddWinsSetWithACL/index.ts
@@ -23,10 +23,7 @@ export class AddWinsSetWithACL<T> implements DRP {
 		if (!this.state.get(value)) this.state.set(value, true);
 	}
 
-	add(sender: string, value: T): void {
-		if (this.acl && !this.acl.isWriter(sender)) {
-			throw new Error("Only writers can add values.");
-		}
+	add(value: T): void {
 		this._add(value);
 	}
 
@@ -34,10 +31,7 @@ export class AddWinsSetWithACL<T> implements DRP {
 		if (this.state.get(value)) this.state.set(value, false);
 	}
 
-	remove(sender: string, value: T): void {
-		if (this.acl && !this.acl.isWriter(sender)) {
-			throw new Error("Only writers can remove values.");
-		}
+	remove(value: T): void {
 		this._remove(value);
 	}
 

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -165,7 +165,7 @@ export class DRPObject implements IDRPObject {
 
 			try {
 				const drp = this._computeDRP(vertex.dependencies);
-				if (drp.acl && !drp.acl.isWriter(vertex.peerId)) {
+				if (!this._checkWriterPermission(drp, vertex.peerId)) {
 					throw new Error(`${vertex.peerId} does not have write permission.`);
 				}
 
@@ -200,6 +200,13 @@ export class DRPObject implements IDRPObject {
 		for (const callback of this.subscriptions) {
 			callback(this, origin, vertices);
 		}
+	}
+
+	private _checkWriterPermission(drp: DRP, peerId: string): boolean {
+		if (drp.acl) {
+			return drp.acl.isWriter(peerId);
+		}
+		return true;
 	}
 
 	private _applyOperation(drp: DRP, operation: Operation) {

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -13,8 +13,8 @@ import { ObjectSet } from "./utils/objectSet.js";
 
 export * as ObjectPb from "./proto/drp/object/v1/object_pb.js";
 export * from "./hashgraph/index.js";
-import { cloneDeep } from "es-toolkit";
 import { stat } from "node:fs";
+import { cloneDeep } from "es-toolkit";
 
 export interface IACL {
 	isWriter: (peerId: string) => boolean;

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -233,7 +233,7 @@ export class DRPObject implements IDRPObject {
 		target[methodName](...args);
 	}
 
-	// compute the DRP based on all dependencies of the current vertex using partial linearization 
+	// compute the DRP based on all dependencies of the current vertex using partial linearization
 	private _computeDRP(
 		vertexDependencies: Hash[],
 		vertexOperation?: Operation | undefined,

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -177,10 +177,7 @@ export class DRPObject implements IDRPObject {
 					vertex.signature,
 				);
 
-				const args = Array.isArray(vertex.operation.value)
-					? vertex.operation.value
-					: [vertex.operation.value];
-				drp[vertex.operation.type](...args);
+				this._applyOperation(drp, vertex.operation);
 				this._setState(vertex, this._getDRPState(drp));
 			} catch (e) {
 				missing.push(vertex.hash);

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -13,7 +13,6 @@ import { ObjectSet } from "./utils/objectSet.js";
 
 export * as ObjectPb from "./proto/drp/object/v1/object_pb.js";
 export * from "./hashgraph/index.js";
-import { stat } from "node:fs";
 import { cloneDeep } from "es-toolkit";
 
 export interface IACL {

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -236,7 +236,7 @@ export class DRPObject implements IDRPObject {
 	// compute the DRP based on all dependencies of the current vertex using partial linearization
 	private _computeDRP(
 		vertexDependencies: Hash[],
-		vertexOperation?: Operation | undefined,
+		vertexOperation?: Operation,
 	): DRP {
 		const subgraph: ObjectSet<Hash> = new ObjectSet();
 		const lca =
@@ -278,22 +278,24 @@ export class DRPObject implements IDRPObject {
 	private _getDRPState(
 		drp: DRP,
 		// biome-ignore lint: values can be anything
-	): Map<string, any> {
+	): DRPState {
 		const varNames: string[] = Object.keys(drp);
 		// biome-ignore lint: values can be anything
-		const newState: Map<string, any> = new Map();
+		const drpState: DRPState = {
+			state: new Map(),
+		};
 		for (const varName of varNames) {
-			newState.set(varName, drp[varName]);
+			drpState.state.set(varName, drp[varName]);
 		}
-		return newState;
+		return drpState;
 	}
 
 	// compute the DRP state based on all dependencies of the current vertex
 	private _computeDRPState(
 		vertexDependencies: Hash[],
-		vertexOperation?: Operation | undefined,
+		vertexOperation?: Operation,
 		// biome-ignore lint: values can be anything
-	): Map<string, any> {
+	): DRPState {
 		const drp = this._computeDRP(vertexDependencies, vertexOperation);
 		return this._getDRPState(drp);
 	}
@@ -302,12 +304,12 @@ export class DRPObject implements IDRPObject {
 	private _setState(
 		vertex: Vertex,
 		// biome-ignore lint: values can be anything
-		state?: Map<string, any>,
+		drpState?: DRPState,
 	) {
-		this.states.set(vertex.hash, {
-			state:
-				state ?? this._computeDRPState(vertex.dependencies, vertex.operation),
-		});
+		this.states.set(
+			vertex.hash,
+			drpState ?? this._computeDRPState(vertex.dependencies, vertex.operation),
+		);
 	}
 
 	// update the DRP's attributes based on all the vertices in the hashgraph
@@ -317,7 +319,7 @@ export class DRPObject implements IDRPObject {
 		}
 		const currentDRP = this.drp as DRP;
 		const newState = this._computeDRPState(this.hashGraph.getFrontier());
-		for (const [key, value] of newState.entries()) {
+		for (const [key, value] of newState.state.entries()) {
 			if (key in currentDRP && typeof currentDRP[key] !== "function") {
 				currentDRP[key] = value;
 			}

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -202,6 +202,7 @@ export class DRPObject implements IDRPObject {
 		}
 	}
 
+	// check if the given peer has write permission
 	private _checkWriterPermission(drp: DRP, peerId: string): boolean {
 		if (drp.acl) {
 			return drp.acl.isWriter(peerId);
@@ -209,6 +210,7 @@ export class DRPObject implements IDRPObject {
 		return true;
 	}
 
+	// apply the operation to the DRP
 	private _applyOperation(drp: DRP, operation: Operation) {
 		const { type, value } = operation;
 
@@ -231,6 +233,7 @@ export class DRPObject implements IDRPObject {
 		target[methodName](...args);
 	}
 
+	// compute the DRP based on all dependencies of the current vertex using partial linearization 
 	private _computeDRP(
 		vertexDependencies: Hash[],
 		vertexOperation?: Operation | undefined,
@@ -271,6 +274,7 @@ export class DRPObject implements IDRPObject {
 		return drp;
 	}
 
+	// get the map representing the state of the given DRP by mapping variable names to their corresponding values
 	private _getDRPState(
 		drp: DRP,
 		// biome-ignore lint: values can be anything
@@ -284,6 +288,7 @@ export class DRPObject implements IDRPObject {
 		return newState;
 	}
 
+	// compute the DRP state based on all dependencies of the current vertex
 	private _computeDRPState(
 		vertexDependencies: Hash[],
 		vertexOperation?: Operation | undefined,
@@ -293,6 +298,7 @@ export class DRPObject implements IDRPObject {
 		return this._getDRPState(drp);
 	}
 
+	// store the state of the DRP corresponding to the given vertex
 	private _setState(
 		vertex: Vertex,
 		// biome-ignore lint: values can be anything
@@ -304,6 +310,7 @@ export class DRPObject implements IDRPObject {
 		});
 	}
 
+	// update the DRP's attributes based on all the vertices in the hashgraph
 	private _updateDRPState() {
 		if (!this.drp) {
 			return;

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -754,11 +754,11 @@ describe("Writer permission tests", () => {
 
 	test("Discard vertex if writer permission is revoked", () => {
 		/*
-		                                              __ V4:ADD(1) --
-		                                             /                \
-		  ROOT -- V1:GRANT(peer2) -- V2:grant(peer3)                   V6:REVOKE(peer3) -- V7:ADD(4)
-		                                             \                /
-		                                              -- V5:ADD(2) --
+			                                            __ V4:ADD(1) --
+			                                           /                \
+		  ROOT -- V1:GRANT(peer2) -- V2:grant(peer3)                    V6:REVOKE(peer3) -- V7:ADD(4)
+			                                           \                /
+			                                            -- V5:ADD(2) --
 		*/
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -754,11 +754,11 @@ describe("Writer permission tests", () => {
 
 	test("Discard vertex if writer permission is revoked", () => {
 		/*
-			                                            __ V4:ADD(1) --
-			                                           /                \
-		  ROOT -- V1:GRANT(peer2) -- V2:grant(peer3)                    V6:REVOKE(peer3) -- V7:ADD(4)
-			                                           \                /
-			                                            -- V5:ADD(2) --
+		                                              __ V4:ADD(1) --
+		                                             /                \
+		  ROOT -- V1:GRANT(peer2) -- V2:grant(peer3)                   V6:REVOKE(peer3) -- V7:ADD(4)
+		                                             \                /
+		                                              -- V5:ADD(2) --
 		*/
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -713,12 +713,12 @@ describe("Writer permission tests", () => {
 	});
 
 	test("Node without writer permission can generate vertex locally", () => {
-		const drp2 = obj1.drp as AddWinsSetWithACL<number>;
-		drp2.add(1);
-		drp2.add(2);
+		const drp = obj1.drp as AddWinsSetWithACL<number>;
+		drp.add(1);
+		drp.add(2);
 
-		expect(drp2.contains(1)).toBe(true);
-		expect(drp2.contains(2)).toBe(true);
+		expect(drp.contains(1)).toBe(true);
+		expect(drp.contains(2)).toBe(true);
 	});
 
 	test("Discard vertex if creator does not have write permission", () => {

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -675,7 +675,7 @@ describe("Operation with ACL tests", () => {
 		drp1.acl.grant("peer1", "peer2", "publicKey2");
 		obj2.merge(obj1.hashGraph.getAllVertices());
 
-		drp2.add("peer2", 1);
+		drp2.add(1);
 		obj1.merge(obj2.hashGraph.getAllVertices());
 		expect(drp1.contains(1)).toBe(true);
 	});

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -754,7 +754,7 @@ describe("Writer permission tests", () => {
 
 	test("Discard vertex if writer permission is revoked", () => {
 		/*
-		                                              __ V4:ADD(1) --
+			                                            __ V4:ADD(1) --
 			                                           /                \
 		  ROOT -- V1:GRANT(peer2) -- V2:grant(peer3)                    V6:REVOKE(peer3) -- V7:ADD(4)
 			                                           \                /

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -691,11 +691,103 @@ describe("Operation with ACL tests", () => {
 		obj2.merge(obj1.hashGraph.getAllVertices());
 
 		expect(drp2.acl.isWriter("peer2")).toBe(true);
-		drp2.add("peer2", 1);
+		drp2.add(1);
 
 		obj1.merge(obj2.hashGraph.getAllVertices());
 		drp1.acl.revoke("peer1", "peer2");
 		obj2.merge(obj1.hashGraph.getAllVertices());
 		expect(drp2.acl.isWriter("peer2")).toBe(false);
+	});
+});
+
+describe("Writer permission tests", () => {
+	let obj1: DRPObject;
+	let obj2: DRPObject;
+	let obj3: DRPObject;
+
+	beforeEach(async () => {
+		const peerIdToPublicKeyMap = new Map([["peer1", "publicKey1"]]);
+		obj1 = new DRPObject("peer1", new AddWinsSetWithACL(peerIdToPublicKeyMap));
+		obj2 = new DRPObject("peer2", new AddWinsSetWithACL(peerIdToPublicKeyMap));
+		obj3 = new DRPObject("peer3", new AddWinsSetWithACL(peerIdToPublicKeyMap));
+	});
+
+	test("Node without writer permission can generate vertex locally", () => {
+		const drp2 = obj1.drp as AddWinsSetWithACL<number>;
+		drp2.add(1);
+		drp2.add(2);
+
+		expect(drp2.contains(1)).toBe(true);
+		expect(drp2.contains(2)).toBe(true);
+	});
+
+	test("Discard vertex if creator does not have write permission", () => {
+		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
+		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+
+		drp1.add(1);
+		drp2.add(2);
+
+		obj1.merge(obj2.hashGraph.getAllVertices());
+		expect(drp1.contains(2)).toBe(false);
+	});
+
+	test("Accept vertex if creator has write permission", () => {
+		/*
+		  ROOT -- V1:ADD(1) -- V2:GRANT(peer2) -- V3:ADD(4)
+		*/
+		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
+		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+
+		drp1.add(1);
+		drp1.acl.grant("peer1", "peer2", "publicKey2");
+		expect(drp1.acl.isAdmin("peer1")).toBe(true);
+
+		obj2.merge(obj1.hashGraph.getAllVertices());
+		expect(drp2.contains(1)).toBe(true);
+		expect(drp2.acl.isWriter("peer2")).toBe(true);
+
+		drp2.add(4);
+		obj1.merge(obj2.hashGraph.getAllVertices());
+		expect(drp1.contains(4)).toBe(true);
+	});
+
+	test("Discard vertex if writer permission is revoked", () => {
+		/*
+		                                              __ V4:ADD(1) --
+			                                           /                \
+		  ROOT -- V1:GRANT(peer2) -- V2:grant(peer3)                    V6:REVOKE(peer3) -- V7:ADD(4)
+			                                           \                /
+			                                            -- V5:ADD(2) --
+		*/
+		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
+		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+		const drp3 = obj3.drp as AddWinsSetWithACL<number>;
+
+		drp1.acl.grant("peer1", "peer2", "publicKey2");
+		drp1.acl.grant("peer1", "peer3", "publicKey3");
+		obj2.merge(obj1.hashGraph.getAllVertices());
+		obj3.merge(obj1.hashGraph.getAllVertices());
+
+		drp2.add(1);
+		drp3.add(2);
+		obj1.merge(obj2.hashGraph.getAllVertices());
+		obj1.merge(obj3.hashGraph.getAllVertices());
+		obj2.merge(obj3.hashGraph.getAllVertices());
+		obj3.merge(obj2.hashGraph.getAllVertices());
+		expect(drp1.contains(1)).toBe(true);
+		expect(drp1.contains(2)).toBe(true);
+
+		drp1.acl.revoke("peer1", "peer3");
+		obj3.merge(obj1.hashGraph.getAllVertices());
+		drp3.add(3);
+		obj2.merge(obj3.hashGraph.getAllVertices());
+		expect(drp2.contains(3)).toBe(false);
+
+		drp2.add(4);
+		obj1.merge(obj2.hashGraph.getAllVertices());
+		obj1.merge(obj3.hashGraph.getAllVertices());
+		expect(drp1.contains(3)).toBe(false);
+		expect(drp1.contains(4)).toBe(true);
 	});
 });


### PR DESCRIPTION
Implemented a writer permission check before merging vertices.

* If ACL exists, verify permissions using drp.acl.isWriter(peerId).
* If there is no ACL, proceed with blind merging.

Update AddWinsSetWithACL because there is no need to check writer permission in the ACL. Updated tests to validate both scenarios. Resolve #302 