### PR TITLE
feat: handle acl operations

### DIFF
--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -106,7 +106,9 @@ export class DRPObject implements IDRPObject {
 		const obj = this;
 		return {
 			get(target, propKey, receiver) {
-				if (typeof target[propKey as keyof object] === "function") {
+				const value = Reflect.get(target, propKey, receiver);
+
+				if (typeof value === "function") {
 					return new Proxy(target[propKey as keyof object], {
 						apply(applyTarget, thisArg, args) {
 							if ((thisArg.operations as string[]).includes(propKey as string))
@@ -118,7 +120,12 @@ export class DRPObject implements IDRPObject {
 						},
 					});
 				}
-				return Reflect.get(target, propKey, receiver);
+
+				if (propKey === "acl" && typeof value === "object" && value !== null) {
+					return new Proxy(value, this);
+				}
+
+				return value;
 			},
 		};
 	}

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -121,7 +121,7 @@ export class DRPObject implements IDRPObject {
 					});
 				}
 
-				if (propKey === "acl" && typeof value === "object" && value !== null) {
+				if (typeof value === "object" && value !== null && propKey === "acl") {
 					return new Proxy(
 						value,
 						obj.proxyDRPHandler(

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -102,27 +102,32 @@ export class DRPObject implements IDRPObject {
 	}
 
 	// This function is black magic, it allows us to intercept calls to the DRP object
-	proxyDRPHandler(): ProxyHandler<object> {
+	proxyDRPHandler(parentProp?: string): ProxyHandler<object> {
 		const obj = this;
 		return {
 			get(target, propKey, receiver) {
 				const value = Reflect.get(target, propKey, receiver);
 
 				if (typeof value === "function") {
+					const fullPropKey = parentProp
+						? `${parentProp}.${String(propKey)}`
+						: String(propKey);
 					return new Proxy(target[propKey as keyof object], {
 						apply(applyTarget, thisArg, args) {
 							if ((thisArg.operations as string[]).includes(propKey as string))
-								obj.callFn(
-									propKey as string,
-									args.length === 1 ? args[0] : args,
-								);
+								obj.callFn(fullPropKey, args.length === 1 ? args[0] : args);
 							return Reflect.apply(applyTarget, thisArg, args);
 						},
 					});
 				}
 
 				if (propKey === "acl" && typeof value === "object" && value !== null) {
-					return new Proxy(value, this);
+					return new Proxy(
+						value,
+						obj.proxyDRPHandler(
+							parentProp ? `${parentProp}.${String(propKey)}` : String(propKey),
+						),
+					);
 				}
 
 				return value;
@@ -191,6 +196,28 @@ export class DRPObject implements IDRPObject {
 		}
 	}
 
+	private _applyOperation(drp: DRP, operation: Operation) {
+		const { type, value } = operation;
+
+		const typeParts = type.split(".");
+		// biome-ignore lint: target can be anything
+		let target: any = drp;
+		for (let i = 0; i < typeParts.length - 1; i++) {
+			target = target[typeParts[i]];
+			if (!target) {
+				throw new Error(`Invalid operation type: ${type}`);
+			}
+		}
+
+		const methodName = typeParts[typeParts.length - 1];
+		if (typeof target[methodName] !== "function") {
+			throw new Error(`${type} is not a function`);
+		}
+
+		const args = Array.isArray(value) ? value : [value];
+		target[methodName](...args);
+	}
+
 	private _computeState(
 		vertexDependencies: Hash[],
 		vertexOperation?: Operation | undefined,
@@ -223,14 +250,10 @@ export class DRPObject implements IDRPObject {
 		}
 
 		for (const op of linearizedOperations) {
-			const args = Array.isArray(op.value) ? op.value : [op.value];
-			drp[op.type](...args);
+			this._applyOperation(drp, op);
 		}
 		if (vertexOperation) {
-			const args = Array.isArray(vertexOperation.value)
-				? vertexOperation.value
-				: [vertexOperation.value];
-			drp[vertexOperation.type](...args);
+			this._applyOperation(drp, vertexOperation);
 		}
 
 		const varNames: string[] = Object.keys(drp);

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -1,7 +1,7 @@
+import { AddWinsSetWithACL } from "@topology-foundation/blueprints/src/AddWinsSetWithACL/index.js";
 import { beforeEach, describe, expect, test } from "vitest";
 import { AddWinsSet } from "../../blueprints/src/AddWinsSet/index.js";
 import { DRPObject, type Operation, OperationType } from "../src/index.js";
-import { AddWinsSetWithACL } from "@topology-foundation/blueprints/src/AddWinsSetWithACL/index.js";
 
 describe("HashGraph construction tests", () => {
 	let obj1: DRPObject;
@@ -653,10 +653,10 @@ describe("Operation with ACL tests", () => {
 	});
 
 	test("Node with admin permission can grant permission to other nodes", () => {
-	  /*
+		/*
 	    ROOT -- V1:GRANT("peer2")
 	  */
-	 
+
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
 		drp1.acl.grant("peer1", "peer2", "publicKey2");

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -653,7 +653,7 @@ describe("Operation with ACL tests", () => {
 	});
 
 	test("Node with admin permission can grant permission to other nodes", () => {
-		/*
+	  /*
 	    ROOT -- V1:GRANT("peer2")
 	  */
 

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -659,8 +659,43 @@ describe("Operation with ACL tests", () => {
 
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+		
 		drp1.acl.grant("peer1", "peer2", "publicKey2");
 		obj2.merge(obj1.hashGraph.getAllVertices());
 		expect(drp2.acl.isWriter("peer2")).toBe(true);
+	});
+
+	test("Node with writer permission can create vertices", () => {
+		/*
+		  ROOT -- V1:GRANT("peer2") -- V2:ADD(1)
+		*/
+		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
+		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+		
+		drp1.acl.grant("peer1", "peer2", "publicKey2");
+		obj2.merge(obj1.hashGraph.getAllVertices());
+		
+		drp2.add("peer2", 1);
+		obj1.merge(obj2.hashGraph.getAllVertices());
+		expect(drp1.contains(1)).toBe(true);
+	});
+
+	test("Revoke permission from writer", () => {
+		/*
+		  ROOT -- V1:GRANT("peer2") -- V2:ADD(1) -- V3:REVOKE("peer2")
+		*/
+		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
+		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+		
+		drp1.acl.grant("peer1", "peer2", "publicKey2");
+		obj2.merge(obj1.hashGraph.getAllVertices());
+		
+		expect(drp2.acl.isWriter("peer2")).toBe(true);
+		drp2.add("peer2", 1);
+
+		obj1.merge(obj2.hashGraph.getAllVertices());
+		drp1.acl.revoke("peer1", "peer2");
+		obj2.merge(obj1.hashGraph.getAllVertices());
+		expect(drp2.acl.isWriter("peer2")).toBe(false);
 	});
 });

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { AddWinsSet } from "../../blueprints/src/AddWinsSet/index.js";
-import { PseudoRandomWinsSet } from "../../blueprints/src/PseudoRandomWinsSet/index.js";
 import { DRPObject, type Operation, OperationType } from "../src/index.js";
+import { AddWinsSetWithACL } from "@topology-foundation/blueprints/src/AddWinsSetWithACL/index.js";
 
 describe("HashGraph construction tests", () => {
 	let obj1: DRPObject;
@@ -631,5 +631,36 @@ describe("Vertex timestamp tests", () => {
 				"",
 			),
 		).toThrowError("Invalid timestamp detected.");
+	});
+});
+
+describe("Operation with ACL tests", () => {
+	let obj1: DRPObject;
+	let obj2: DRPObject;
+
+	beforeEach(async () => {
+		const peerIdToPublicKey = new Map<string, string>([
+			["peer1", "publicKey1"],
+		]);
+		obj1 = new DRPObject(
+			"peer1",
+			new AddWinsSetWithACL<number>(peerIdToPublicKey),
+		);
+		obj2 = new DRPObject(
+			"peer2",
+			new AddWinsSetWithACL<number>(peerIdToPublicKey),
+		);
+	});
+
+	test("Node with admin permission can grant permission to other nodes", () => {
+	  /*
+	    ROOT -- V1:GRANT("peer2")
+	  */
+	 
+		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
+		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
+		drp1.acl.grant("peer1", "peer2", "publicKey2");
+		obj2.merge(obj1.hashGraph.getAllVertices());
+		expect(drp2.acl.isWriter("peer2")).toBe(true);
 	});
 });

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -653,9 +653,9 @@ describe("Operation with ACL tests", () => {
 	});
 
 	test("Node with admin permission can grant permission to other nodes", () => {
-	  /*
-	    ROOT -- V1:GRANT("peer2")
-	  */
+		/*
+		  ROOT -- V1:GRANT("peer2")
+		*/
 
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -659,7 +659,7 @@ describe("Operation with ACL tests", () => {
 
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
-		
+
 		drp1.acl.grant("peer1", "peer2", "publicKey2");
 		obj2.merge(obj1.hashGraph.getAllVertices());
 		expect(drp2.acl.isWriter("peer2")).toBe(true);
@@ -671,10 +671,10 @@ describe("Operation with ACL tests", () => {
 		*/
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
-		
+
 		drp1.acl.grant("peer1", "peer2", "publicKey2");
 		obj2.merge(obj1.hashGraph.getAllVertices());
-		
+
 		drp2.add("peer2", 1);
 		obj1.merge(obj2.hashGraph.getAllVertices());
 		expect(drp1.contains(1)).toBe(true);
@@ -686,10 +686,10 @@ describe("Operation with ACL tests", () => {
 		*/
 		const drp1 = obj1.drp as AddWinsSetWithACL<number>;
 		const drp2 = obj2.drp as AddWinsSetWithACL<number>;
-		
+
 		drp1.acl.grant("peer1", "peer2", "publicKey2");
 		obj2.merge(obj1.hashGraph.getAllVertices());
-		
+
 		expect(drp2.acl.isWriter("peer2")).toBe(true);
 		drp2.add("peer2", 1);
 


### PR DESCRIPTION
* Enhances the proxyDRPHandler to handle nested objects like acl, ensuring full method paths (e.g., acl.grant) are intercepted closes #309 
* Fixed error handling for vertexOperation.type when it refers to nested properties, closes #306 