### PR TITLE
feat: add development env config with local node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules/
 **/tsconfig.tsbuildinfo
 coverage/*
 .vscode/*
+
+# macOS
+.DS_Store

--- a/examples/canvas/.env.local-node
+++ b/examples/canvas/.env.local-node
@@ -1,0 +1,1 @@
+VITE_BOOTSTRAP_PEERS="/ip4/127.0.0.1/tcp/50000/ws/p2p/12D3KooWC6sm9iwmYbeQJCJipKTRghmABNz1wnpJANvSMabvecwJ"

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -6,6 +6,7 @@
 		"build": "vite build",
 		"clean": "rm -rf dist/ node_modules/",
 		"dev": "vite serve",
+		"local": "vite serve --mode local-node",
 		"start": "vite preview --host --port 5173"
 	},
 	"dependencies": {

--- a/examples/canvas/src/index.ts
+++ b/examples/canvas/src/index.ts
@@ -2,7 +2,13 @@ import { DRPNode } from "@ts-drp/node";
 import type { DRPObject } from "@ts-drp/object";
 import { Canvas } from "./objects/canvas";
 
-const node = new DRPNode();
+const node = new DRPNode({
+	network_config: import.meta.env.VITE_BOOTSTRAP_PEERS
+		? {
+			bootstrap_peers: [import.meta.env.VITE_BOOTSTRAP_PEERS],
+		}
+		: {},
+});
 let drpObject: DRPObject;
 let canvasDRP: Canvas;
 let peers: string[] = [];

--- a/examples/canvas/vite-env.d.ts
+++ b/examples/canvas/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	readonly VITE_BOOTSTRAP_PEERS: string
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv
+}

--- a/examples/chat/.env.local-node
+++ b/examples/chat/.env.local-node
@@ -1,0 +1,1 @@
+VITE_BOOTSTRAP_PEERS="/ip4/127.0.0.1/tcp/50000/ws/p2p/12D3KooWC6sm9iwmYbeQJCJipKTRghmABNz1wnpJANvSMabvecwJ"

--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -6,6 +6,7 @@
 		"build": "vite build",
 		"clean": "rm -rf dist/ node_modules/",
 		"dev": "vite serve",
+		"local": "vite serve --mode local-node",
 		"start": "vite preview --host --port 5173"
 	},
 	"dependencies": {

--- a/examples/chat/src/index.ts
+++ b/examples/chat/src/index.ts
@@ -2,7 +2,13 @@ import { DRPNode } from "@ts-drp/node";
 import type { DRPObject } from "@ts-drp/object";
 import { Chat } from "./objects/chat";
 
-const node = new DRPNode();
+const node = new DRPNode({
+	network_config: import.meta.env.VITE_BOOTSTRAP_PEERS
+		? {
+			bootstrap_peers: [import.meta.env.VITE_BOOTSTRAP_PEERS],
+		}
+		: {},
+});
 let drpObject: DRPObject;
 let chatDRP: Chat;
 let peers: string[] = [];

--- a/examples/chat/vite-env.d.ts
+++ b/examples/chat/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	readonly VITE_BOOTSTRAP_PEERS: string
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv
+}

--- a/examples/grid/.env.local-node
+++ b/examples/grid/.env.local-node
@@ -1,0 +1,1 @@
+VITE_BOOTSTRAP_PEERS="/ip4/127.0.0.1/tcp/50000/ws/p2p/12D3KooWC6sm9iwmYbeQJCJipKTRghmABNz1wnpJANvSMabvecwJ"

--- a/examples/grid/package.json
+++ b/examples/grid/package.json
@@ -6,6 +6,7 @@
 		"build": "vite build",
 		"clean": "rm -rf dist/ node_modules/",
 		"dev": "vite serve",
+		"local": "vite serve --mode local-node",
 		"start": "vite preview --host --port 5173"
 	},
 	"dependencies": {

--- a/examples/grid/src/index.ts
+++ b/examples/grid/src/index.ts
@@ -3,7 +3,13 @@ import type { DRPObject } from "@ts-drp/object";
 import { Grid } from "./objects/grid";
 import { hslToRgb, rgbToHex, rgbToHsl } from "./util/color";
 
-const node = new DRPNode();
+const node = new DRPNode({
+	network_config: import.meta.env.VITE_BOOTSTRAP_PEERS
+		? {
+			bootstrap_peers: [import.meta.env.VITE_BOOTSTRAP_PEERS],
+		}
+		: {},
+});
 let drpObject: DRPObject;
 let gridDRP: Grid;
 let peers: string[] = [];

--- a/examples/grid/vite-env.d.ts
+++ b/examples/grid/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	readonly VITE_BOOTSTRAP_PEERS: string
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
The goal of this PR is to add a way to easily be able to configure the bootstrap peers on the example.
Like that people will be able to configure the node using the .env with the mode of their choice.
Right now only the bootstrap node will be configurable but in the future we might want to have other stuff configurable

Signed-off-by: Sacha Froment <sfroment42@gmail.com>
