### PR TITLE
fix: rm ops arr perf

### DIFF
--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -8,7 +8,12 @@
 	},
 	"type": "module",
 	"types": "./dist/src/index.d.ts",
-	"files": ["src", "dist", "!dist/test", "!**/*.tsbuildinfo"],
+	"files": [
+		"src",
+		"dist",
+		"!dist/test",
+		"!**/*.tsbuildinfo"
+	],
 	"main": "./dist/src/index.js",
 	"exports": {
 		".": {
@@ -27,10 +32,12 @@
 	"devDependencies": {
 		"@bufbuild/protobuf": "^2.0.0",
 		"benchmark": "^2.1.4",
-		"tsx": "4.19.1",
-		"es-toolkit": "1.30.1"
+		"es-toolkit": "1.30.1",
+		"tsx": "4.19.1"
 	},
 	"dependencies": {
-		"@ts-drp/logger": "^0.4.4"
+		"@ts-drp/logger": "^0.4.4",
+		"fast-deep-equal": "^3.1.3",
+		"fast-equals": "^5.2.2"
 	}
 }

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -1,4 +1,3 @@
-import { deepStrictEqual } from "node:assert";
 import * as crypto from "node:crypto";
 import { Logger, type LoggerOptions } from "@ts-drp/logger";
 import {
@@ -11,10 +10,11 @@ import {
 } from "./hashgraph/index.js";
 import * as ObjectPb from "./proto/drp/object/v1/object_pb.js";
 import { ObjectSet } from "./utils/objectSet.js";
+import { cloneDeep } from "es-toolkit";
+import { deepEqual } from "fast-equals";
 
 export * as ObjectPb from "./proto/drp/object/v1/object_pb.js";
 export * from "./hashgraph/index.js";
-import { cloneDeep } from "es-toolkit";
 
 export interface IACL {
 	grant: (senderId: string, peerId: string, publicKey: string) => void;
@@ -150,9 +150,7 @@ export class DRPObject implements IDRPObject {
 
 		let stateChanged = false;
 		for (const key of Object.keys(preOperationDRP)) {
-			try {
-				deepStrictEqual(preOperationDRP[key], drp[key]);
-			} catch {
+			if (!deepEqual(preOperationDRP[key], drp[key])) {
 				stateChanged = true;
 				break;
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,12 @@ importers:
       '@ts-drp/logger':
         specifier: ^0.4.4
         version: link:../logger
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
+      fast-equals:
+        specifier: ^5.2.2
+        version: 5.2.2
     devDependencies:
       '@bufbuild/protobuf':
         specifier: ^2.0.0
@@ -2960,6 +2966,13 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -8429,6 +8442,10 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.2.2: {}
 
   fast-glob@3.3.2:
     dependencies:


### PR DESCRIPTION
This is a pr on top of the remove operations array pr, for performance improvements.
- It replaces the node assert equal, with a faster library
- ~It checks repeated vertices on the callFn instead of the stack (comparing with the frontier)~

perf (locally): 6 op/s -> 25 ops/s