### PR TITLE
fix: set max reservation to infinity and change topic weight

### DIFF
--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -117,7 +117,11 @@ export class DRPNetworkNode {
 
 		const _bootstrap_services = {
 			..._node_services,
-			relay: circuitRelayServer(),
+			relay: circuitRelayServer({
+				reservations: {
+					maxReservations: Number.POSITIVE_INFINITY,
+				},
+			}),
 		};
 
 		this._node = await createLibp2p({


### PR DESCRIPTION
This PR aim to fix the problem where the bootstrap node is not able to setup the relay for a browser connection.
This PR also upgrade the topic weight of drp::discovery so the score stay up for longer for the peer in this topic.
Maybe we shall decrease the reservationTtl as well as the reservation will stay for long time ? 
Also infinity is maybe too much but right now it will at least mitigate the problem.
Shall we also disable the floodsub fallback on gossipsub ? I would say yes as we don't have handlers for those message. Because a peer might actually fall in that

Signed-off-by: Sacha Froment <sfroment42@gmail.com>
