### PR TITLE
feat: add ping protocol to avoid connection monitor log

### DIFF
--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -37,6 +37,7 @@
 		"@libp2p/dcutr": "^2.0.6",
 		"@libp2p/devtools-metrics": "^1.1.5",
 		"@libp2p/identify": "^3.0.6",
+		"@libp2p/ping": "2.0.9",
 		"@libp2p/pubsub-peer-discovery": "^11.0.0",
 		"@libp2p/webrtc": "^5.0.9",
 		"@libp2p/websockets": "^9.1.1",

--- a/packages/network/src/node.ts
+++ b/packages/network/src/node.ts
@@ -22,6 +22,7 @@ import type {
 	Stream,
 	StreamHandler,
 } from "@libp2p/interface";
+import { ping } from "@libp2p/ping";
 import { pubsubPeerDiscovery } from "@libp2p/pubsub-peer-discovery";
 import { webRTC, webRTCDirect } from "@libp2p/webrtc";
 import { webSockets } from "@libp2p/websockets";
@@ -101,6 +102,7 @@ export class DRPNetworkNode {
 			: [_pubsubPeerDiscovery];
 
 		const _node_services = {
+			ping: ping(),
 			autonat: autoNAT(),
 			dcutr: dcutr(),
 			identify: identify(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@libp2p/identify':
         specifier: ^3.0.6
         version: 3.0.14
+      '@libp2p/ping':
+        specifier: 2.0.9
+        version: 2.0.9
       '@libp2p/pubsub-peer-discovery':
         specifier: ^11.0.0
         version: 11.0.1
@@ -1634,6 +1637,9 @@ packages:
 
   '@libp2p/peer-store@11.0.13':
     resolution: {integrity: sha512-KieXSY8ysyC7ROJ7GI7dtQkowRFDuG2jk5HQedSXNUe74JurG0uI/HddFF8yij+HgY/kZiBwWUQbKrTC4Cewbw==}
+
+  '@libp2p/ping@2.0.9':
+    resolution: {integrity: sha512-esS6crF51u0GwKooTdpFGaEvIA0+UDRyiTnZicUg44WhcM2xpo8kSZh7QTFgEgy1lGD/K/a5KDuSSac4+3EqNA==}
 
   '@libp2p/pubsub-peer-discovery@11.0.1':
     resolution: {integrity: sha512-bT7UO7tQ4mZCPFE0eS8Fx19B8MGzxjbTNR6SwcLGcOqOqUTvc2CLByMvcy3iMXuKjmds6G+VUf5ZMhvjGLTznA==}
@@ -6814,6 +6820,15 @@ snapshots:
       multiformats: 13.3.1
       protons-runtime: 5.5.0
       uint8arraylist: 2.4.8
+      uint8arrays: 5.1.0
+
+  '@libp2p/ping@2.0.9':
+    dependencies:
+      '@libp2p/crypto': 5.0.8
+      '@libp2p/interface': 2.3.0
+      '@libp2p/interface-internal': 2.2.1
+      '@multiformats/multiaddr': 12.3.4
+      it-byte-stream: 1.1.0
       uint8arrays: 5.1.0
 
   '@libp2p/pubsub-peer-discovery@11.0.1':


### PR DESCRIPTION
This PR add the ping protocol as it is used by libp2p by default.
The addition will remove many annoying logs around yamux, and libp2p itself.

Signed-off-by: Sacha Froment <sfroment42@gmail.com>
