### PR TITLE
fix: es-toolkit is a dependency not a dev one

### DIFF
--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.4.4";
+export const VERSION = "0.5.0";

--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -27,12 +27,12 @@
 	"devDependencies": {
 		"@bufbuild/protobuf": "^2.0.0",
 		"benchmark": "^2.1.4",
-		"es-toolkit": "1.30.1",
 		"tsx": "4.19.1"
 	},
 	"dependencies": {
 		"@ts-drp/logger": "^0.5.0",
 		"fast-deep-equal": "^3.1.3",
-		"fast-equals": "^5.2.2"
+		"fast-equals": "^5.2.2",
+		"es-toolkit": "1.30.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,10 +54,10 @@ importers:
   examples/canvas:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -76,10 +76,10 @@ importers:
   examples/chat:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -98,10 +98,10 @@ importers:
   examples/grid:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -120,7 +120,7 @@ importers:
   examples/local-bootstrap:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../../packages/node
     devDependencies:
       '@types/node':
@@ -143,7 +143,7 @@ importers:
         version: 4.1.5
     devDependencies:
       '@ts-drp/object':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../object
 
   packages/logger:
@@ -209,7 +209,7 @@ importers:
         specifier: ^12.3.1
         version: 12.3.4
       '@ts-drp/logger':
-        specifier: ^0.4.4
+        specifier: ^0.5.0
         version: link:../logger
       it-length-prefixed:
         specifier: ^9.1.0
@@ -249,16 +249,16 @@ importers:
         specifier: ^2.1.3
         version: 2.3.0
       '@ts-drp/blueprints':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../blueprints
       '@ts-drp/logger':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../logger
       '@ts-drp/network':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../network
       '@ts-drp/object':
-        specifier: 0.4.4
+        specifier: 0.5.0
         version: link:../object
       commander:
         specifier: ^13.0.0
@@ -289,8 +289,11 @@ importers:
   packages/object:
     dependencies:
       '@ts-drp/logger':
-        specifier: ^0.4.4
+        specifier: ^0.5.0
         version: link:../logger
+      es-toolkit:
+        specifier: 1.30.1
+        version: 1.30.1
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -304,9 +307,6 @@ importers:
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
-      es-toolkit:
-        specifier: 1.30.1
-        version: 1.30.1
       tsx:
         specifier: 4.19.1
         version: 4.19.1


### PR DESCRIPTION
While trying to upgrade drp-mouse this came up:
```
> drp-mouse@1.0.0 build
> webpack --mode production

assets by status 1.29 MiB [cached] 3 assets
orphan modules 2.14 MiB [orphan] 526 modules
runtime modules 1010 bytes 5 modules
cacheable modules 3.35 MiB
  modules by path ./node_modules/ 3.33 MiB
    javascript modules 3.32 MiB 190 modules
    json modules 12.7 KiB 6 modules
  optional modules 120 bytes [optional]
    buffer (ignored) 15 bytes [optional] [built] [code generated]
    buffer (ignored) 15 bytes [optional] [built] [code generated]
    + 6 modules
  modules by path ./src/ 13.7 KiB
    modules by path ./src/drp/*.ts 3.24 KiB 2 modules
    ./src/content.ts 9.97 KiB [built] [code generated]
    ./src/utils/emojiMapper.ts 541 bytes [built] [code generated]
  + 6 modules

ERROR in ./node_modules/@ts-drp/object/dist/src/index.js 3:0-39
Module not found: Error: Can't resolve 'es-toolkit' in '/topology/drp-mouse-update/node_modules/@ts-drp/object/dist/src'
resolve 'es-toolkit' in '/topology/drp-mouse-update/node_modules/@ts-drp/object/dist/src'
  Parsed request is a module
  using description file: /topology/drp-mouse-update/node_modules/@ts-drp/object/package.json (relative path: ./dist/src)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /topology/drp-mouse-update/node_modules/@ts-drp/object/dist/src/node_modules doesn't exist or is not a directory
      /topology/drp-mouse-update/node_modules/@ts-drp/object/dist/node_modules doesn't exist or is not a directory
      /topology/drp-mouse-update/node_modules/@ts-drp/object/node_modules doesn't exist or is not a directory
      /topology/drp-mouse-update/node_modules/@ts-drp/node_modules doesn't exist or is not a directory
      /topology/drp-mouse-update/node_modules/node_modules doesn't exist or is not a directory
      looking for modules in /topology/drp-mouse-update/node_modules
        single file module
          using description file: /topology/drp-mouse-update/package.json (relative path: ./node_modules/es-toolkit)
            no extension
              Field 'browser' doesn't contain a valid alias configuration
              /topology/drp-mouse-update/node_modules/es-toolkit doesn't exist
            .tsx
              Field 'browser' doesn't contain a valid alias configuration
              /topology/drp-mouse-update/node_modules/es-toolkit.tsx doesn't exist
            .ts
              Field 'browser' doesn't contain a valid alias configuration
              /topology/drp-mouse-update/node_modules/es-toolkit.ts doesn't exist
            .js
              Field 'browser' doesn't contain a valid alias configuration
              /topology/drp-mouse-update/node_modules/es-toolkit.js doesn't exist
        /topology/drp-mouse-update/node_modules/es-toolkit doesn't exist
      /topology/node_modules doesn't exist or is not a directory
      looking for modules in /node_modules
        single file module
          using description file: /package.json (relative path: ./node_modules/es-toolkit)
            no extension
              Field 'browser' doesn't contain a valid alias configuration
              /node_modules/es-toolkit doesn't exist
            .tsx
              Field 'browser' doesn't contain a valid alias configuration
              /node_modules/es-toolkit.tsx doesn't exist
            .ts
              Field 'browser' doesn't contain a valid alias configuration
              /node_modules/es-toolkit.ts doesn't exist
            .js
              Field 'browser' doesn't contain a valid alias configuration
              /node_modules/es-toolkit.js doesn't exist
        /node_modules/es-toolkit doesn't exist
      /Users/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
 @ ./src/drp/cursorDRP.ts
 @ ./src/content.ts 14:20-46

webpack 5.97.1 compiled with 1 error in 9339 ms
```
It's simply due to the fact that the deps is not only a dev one.


Signed-off-by: Sacha Froment <sfroment42@gmail.com>
