### PR TITLE
fix: wrong initial bitset size

### DIFF
--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.5.1";
+export const VERSION = "0.5.2";

--- a/packages/object/src/hashgraph/bitset.ts
+++ b/packages/object/src/hashgraph/bitset.ts
@@ -9,7 +9,7 @@ export class BitSet {
 	private data: Uint32Array;
 
 	constructor(bits: number) {
-		const size = ((bits + 31) / 32) | 0;
+		const size = Math.ceil(bits / 32);
 		this.data = new Uint32Array(size);
 	}
 

--- a/packages/object/src/hashgraph/bitset.ts
+++ b/packages/object/src/hashgraph/bitset.ts
@@ -81,25 +81,4 @@ export class BitSet {
 			.map((int) => int.toString(2).padStart(32, "0"))
 			.join("");
 	}
-
-	findNext(index: number, bit: number): number {
-		let wordIndex = Math.floor((index + 1) / 32);
-		const bitIndex = (index + 1) % 32;
-		let mask = ~((1 << bitIndex) - 1);
-
-		while (wordIndex < this.data.length) {
-			let currentWord = this.data[wordIndex];
-			if (bit === 0) currentWord = ~currentWord;
-			currentWord &= mask;
-
-			if (currentWord !== 0) {
-				return wordIndex * 32 + 31 - Math.clz32(currentWord & -currentWord);
-			}
-
-			wordIndex++;
-			mask = ~0;
-		}
-
-		return this.data.length * 32;
-	}
 }

--- a/packages/object/src/hashgraph/bitset.ts
+++ b/packages/object/src/hashgraph/bitset.ts
@@ -8,8 +8,8 @@
 export class BitSet {
 	private data: Uint32Array;
 
-	constructor(size = 1) {
-		// Always start with size 32
+	constructor(bits: number) {
+		const size = ((bits + 31) / 32) | 0;
 		this.data = new Uint32Array(size);
 	}
 
@@ -42,7 +42,7 @@ export class BitSet {
 
 	// AND two bitsets of the same size
 	and(other: BitSet): BitSet {
-		const result = new BitSet(this.data.length);
+		const result = new BitSet(this.data.length * 32);
 		for (let i = 0; i < this.data.length; i++) {
 			result.data[i] = this.data[i] & other.data[i];
 		}
@@ -51,7 +51,7 @@ export class BitSet {
 
 	// OR two bitsets of the same size
 	or(other: BitSet): BitSet {
-		const result = new BitSet(this.data.length);
+		const result = new BitSet(this.data.length * 32);
 		for (let i = 0; i < this.data.length; i++) {
 			result.data[i] = this.data[i] | other.data[i];
 		}
@@ -60,7 +60,7 @@ export class BitSet {
 
 	// XOR two bitsets of the same size
 	xor(other: BitSet): BitSet {
-		const result = new BitSet(this.data.length);
+		const result = new BitSet(this.data.length * 32);
 		for (let i = 0; i < this.data.length; i++) {
 			result.data[i] = this.data[i] ^ other.data[i];
 		}

--- a/packages/object/src/hashgraph/index.ts
+++ b/packages/object/src/hashgraph/index.ts
@@ -481,10 +481,6 @@ export class HashGraph {
 		return true;
 	}
 
-	findNextCausallyUnrelated(hash: Hash, start: number): number | undefined {
-		return this.reachablePredecessors.get(hash)?.findNext(start, 0);
-	}
-
 	areCausallyRelatedUsingBFS(hash1: Hash, hash2: Hash): boolean {
 		return (
 			this._areCausallyRelatedUsingBFS(hash1, hash2) ||

--- a/packages/object/tests/bitset.test.ts
+++ b/packages/object/tests/bitset.test.ts
@@ -6,7 +6,22 @@ describe("BitSet Test", () => {
 
 	beforeEach(() => {
 		// Bitset of size 64
-		bitset = new BitSet(2);
+		bitset = new BitSet(64);
+	});
+
+	test("Test: Bitset data", () => {
+		for (let i = 0; i < 64; i++) {
+			bitset.set(i, true);
+		}
+		for (let i = 0; i < 64; i++) {
+			expect(bitset.get(i)).toBe(true);
+		}
+		for (let i = 0; i < 64; i++) {
+			bitset.set(i, false);
+		}
+		for (let i = 0; i < 64; i++) {
+			expect(bitset.get(i)).toBe(false);
+		}
 	});
 
 	test("Test: BitSet", () => {
@@ -24,7 +39,7 @@ describe("BitSet Test", () => {
 
 		bitset.clear();
 
-		let other: BitSet = new BitSet(2);
+		let other: BitSet = new BitSet(64);
 		other.set(0, true);
 		other = other.or(bitset);
 		expect(other.get(0)).toBe(true);

--- a/packages/object/tests/bitset.test.ts
+++ b/packages/object/tests/bitset.test.ts
@@ -5,21 +5,21 @@ describe("BitSet Test", () => {
 	let bitset: BitSet;
 
 	beforeEach(() => {
-		// Bitset of size 95
-		bitset = new BitSet(95);
+		// Bitset of size 65
+		bitset = new BitSet(65);
 	});
 
 	test("Test: Bitset data", () => {
-		for (let i = 0; i < 95; i++) {
+		for (let i = 0; i < 65; i++) {
 			bitset.set(i, true);
 		}
-		for (let i = 0; i < 95; i++) {
+		for (let i = 0; i < 65; i++) {
 			expect(bitset.get(i)).toBe(true);
 		}
-		for (let i = 0; i < 95; i++) {
+		for (let i = 0; i < 65; i++) {
 			bitset.set(i, false);
 		}
-		for (let i = 0; i < 95; i++) {
+		for (let i = 0; i < 65; i++) {
 			expect(bitset.get(i)).toBe(false);
 		}
 	});
@@ -39,7 +39,7 @@ describe("BitSet Test", () => {
 
 		bitset.clear();
 
-		let other: BitSet = new BitSet(95);
+		let other: BitSet = new BitSet(65);
 		other.set(0, true);
 		other = other.or(bitset);
 		expect(other.get(0)).toBe(true);

--- a/packages/object/tests/bitset.test.ts
+++ b/packages/object/tests/bitset.test.ts
@@ -5,21 +5,21 @@ describe("BitSet Test", () => {
 	let bitset: BitSet;
 
 	beforeEach(() => {
-		// Bitset of size 64
-		bitset = new BitSet(64);
+		// Bitset of size 95
+		bitset = new BitSet(95);
 	});
 
 	test("Test: Bitset data", () => {
-		for (let i = 0; i < 64; i++) {
+		for (let i = 0; i < 95; i++) {
 			bitset.set(i, true);
 		}
-		for (let i = 0; i < 64; i++) {
+		for (let i = 0; i < 95; i++) {
 			expect(bitset.get(i)).toBe(true);
 		}
-		for (let i = 0; i < 64; i++) {
+		for (let i = 0; i < 95; i++) {
 			bitset.set(i, false);
 		}
-		for (let i = 0; i < 64; i++) {
+		for (let i = 0; i < 95; i++) {
 			expect(bitset.get(i)).toBe(false);
 		}
 	});
@@ -39,7 +39,7 @@ describe("BitSet Test", () => {
 
 		bitset.clear();
 
-		let other: BitSet = new BitSet(64);
+		let other: BitSet = new BitSet(95);
 		other.set(0, true);
 		other = other.or(bitset);
 		expect(other.get(0)).toBe(true);
@@ -49,39 +49,5 @@ describe("BitSet Test", () => {
 
 		other = other.and(bitset);
 		expect(other.get(0)).toBe(false);
-	});
-
-	test("find next index of one-bit", () => {
-		bitset.set(5, true);
-		bitset.set(10, true);
-		bitset.set(20, true);
-		bitset.set(30, true);
-		bitset.set(40, true);
-
-		expect(bitset.findNext(0, 1)).toBe(5);
-		expect(bitset.findNext(5, 1)).toBe(10);
-		expect(bitset.findNext(10, 1)).toBe(20);
-		expect(bitset.findNext(20, 1)).toBe(30);
-		expect(bitset.findNext(30, 1)).toBe(40);
-		expect(bitset.findNext(40, 1)).toBe(64);
-	});
-
-	test("find next index of zero-bit", () => {
-		for (let i = 0; i < 64; i++) {
-			bitset.set(i, true);
-		}
-
-		bitset.set(5, false);
-		bitset.set(10, false);
-		bitset.set(20, false);
-		bitset.set(30, false);
-		bitset.set(40, false);
-
-		expect(bitset.findNext(0, 0)).toBe(5);
-		expect(bitset.findNext(5, 0)).toBe(10);
-		expect(bitset.findNext(10, 0)).toBe(20);
-		expect(bitset.findNext(20, 0)).toBe(30);
-		expect(bitset.findNext(30, 0)).toBe(40);
-		expect(bitset.findNext(40, 0)).toBe(64);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,10 +54,10 @@ importers:
   examples/canvas:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -76,10 +76,10 @@ importers:
   examples/chat:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -98,10 +98,10 @@ importers:
   examples/grid:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -120,7 +120,7 @@ importers:
   examples/local-bootstrap:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../../packages/node
     devDependencies:
       '@types/node':
@@ -143,7 +143,7 @@ importers:
         version: 4.1.5
     devDependencies:
       '@ts-drp/object':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../object
 
   packages/logger:
@@ -209,7 +209,7 @@ importers:
         specifier: ^12.3.1
         version: 12.3.4
       '@ts-drp/logger':
-        specifier: ^0.5.1
+        specifier: ^0.5.2
         version: link:../logger
       it-length-prefixed:
         specifier: ^9.1.0
@@ -249,16 +249,16 @@ importers:
         specifier: ^2.1.3
         version: 2.3.0
       '@ts-drp/blueprints':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../blueprints
       '@ts-drp/logger':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../logger
       '@ts-drp/network':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../network
       '@ts-drp/object':
-        specifier: 0.5.1
+        specifier: 0.5.2
         version: link:../object
       commander:
         specifier: ^13.0.0
@@ -289,7 +289,7 @@ importers:
   packages/object:
     dependencies:
       '@ts-drp/logger':
-        specifier: ^0.5.1
+        specifier: ^0.5.2
         version: link:../logger
       es-toolkit:
         specifier: 1.30.1


### PR DESCRIPTION
The buffer sizes in the bitsets were calculated incorrectly, causing memory consumption to be 32 times worse.

This PR fixes the issue and removes unused functions.

Memory consumption changes for `obj.hashGraph.reachablePredecessors` during linearization:
- 5k vertices: 349.9 MB -> 12.9 MB
- 2k vertices: 33.7 MB -> 1.5 MB