### PR TITLE
fix: pass addr sorting to connection manager to always dial in a predeterministic way

### DIFF
--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -43,6 +43,7 @@
 		"@libp2p/websockets": "^9.1.1",
 		"@libp2p/webtransport": "^5.0.9",
 		"@multiformats/multiaddr": "^12.3.1",
+		"@multiformats/multiaddr-matcher": "^1.6.0",
 		"@ts-drp/logger": "^0.5.2",
 		"it-length-prefixed": "^9.1.0",
 		"it-map": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@multiformats/multiaddr':
         specifier: ^12.3.1
         version: 12.3.4
+      '@multiformats/multiaddr-matcher':
+        specifier: ^1.6.0
+        version: 1.6.0
       '@ts-drp/logger':
         specifier: ^0.5.2
         version: link:../logger


### PR DESCRIPTION
This PR aim to make the dial consistent even when it's not coming from the identify.
How ? By passing the addr sorting on the connection manager side, which is invoked by calculateMultiaddrs in the libp2p code, which it self is called in dial.
