### PR TITLE
Improv: update operation value

### DIFF
--- a/packages/blueprints/src/ACL/index.ts
+++ b/packages/blueprints/src/ACL/index.ts
@@ -73,7 +73,7 @@ export class ACL implements IACL, DRP {
 			return { action: ActionType.Nop };
 		if (
 			vertices[0].operation.type === vertices[1].operation.type ||
-			vertices[0].operation.value !== vertices[1].operation.value
+			vertices[0].operation.value[0] !== vertices[1].operation.value[0]
 		)
 			return { action: ActionType.Nop };
 

--- a/packages/blueprints/src/AddWinsSet/index.ts
+++ b/packages/blueprints/src/AddWinsSet/index.ts
@@ -39,7 +39,7 @@ export class AddWinsSet<T> implements DRP {
 			vertices[0].operation &&
 			vertices[1].operation &&
 			vertices[0].operation?.type !== vertices[1].operation?.type &&
-			vertices[0].operation?.value === vertices[1].operation?.value
+			vertices[0].operation?.value[0] === vertices[1].operation?.value[0]
 		) {
 			return vertices[0].operation.type === "add"
 				? { action: ActionType.DropRight }

--- a/packages/blueprints/src/AddWinsSetWithACL/index.ts
+++ b/packages/blueprints/src/AddWinsSetWithACL/index.ts
@@ -42,7 +42,7 @@ export class AddWinsSetWithACL<T> implements DRP {
 			return { action: ActionType.Nop };
 		if (
 			vertices[0].operation.type === vertices[1].operation.type ||
-			vertices[0].operation.value !== vertices[1].operation.value
+			vertices[0].operation.value[0] !== vertices[1].operation.value[0]
 		)
 			return { action: ActionType.Nop };
 

--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.5.2";
+export const VERSION = "0.5.3";

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -253,8 +253,7 @@ export class DRPObject implements IDRPObject {
 			throw new Error(`${type} is not a function`);
 		}
 
-		const args = Array.isArray(value) ? value : [value];
-		target[methodName](...args);
+		target[methodName](...value);
 	}
 
 	// compute the DRP based on all dependencies of the current vertex using partial linearization

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -122,7 +122,7 @@ export class DRPObject implements IDRPObject {
 								?.trim()
 								.split(" ")[1];
 							if (!callerName?.startsWith("Proxy."))
-								obj.callFn(fullPropKey, args.length === 1 ? args[0] : args);
+								obj.callFn(fullPropKey, args);
 							return Reflect.apply(applyTarget, thisArg, args);
 						},
 					});

--- a/packages/object/tests/hashgraph.test.ts
+++ b/packages/object/tests/hashgraph.test.ts
@@ -49,8 +49,8 @@ describe("HashGraph construction tests", () => {
 
 		const linearOps = obj2.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 2 },
-			{ type: "add", value: 1 },
+			{ type: "add", value: [2] },
+			{ type: "add", value: [1] },
 		]);
 	});
 
@@ -75,7 +75,7 @@ describe("HashGraph construction tests", () => {
 		obj1.hashGraph.addVertex(
 			{
 				type: "add",
-				value: 1,
+				value: [1],
 			},
 			[hash],
 			"",
@@ -85,7 +85,7 @@ describe("HashGraph construction tests", () => {
 		expect(obj1.hashGraph.selfCheckConstraints()).toBe(false);
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
-		expect(linearOps).toEqual([{ type: "add", value: 1 }]);
+		expect(linearOps).toEqual([{ type: "add", value: [1] }]);
 	});
 });
 
@@ -112,8 +112,8 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
 		]);
 	});
 
@@ -141,8 +141,8 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
 		]);
 	});
 
@@ -170,9 +170,9 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
-			{ type: "add", value: 2 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
+			{ type: "add", value: [2] },
 		]);
 	});
 
@@ -204,9 +204,9 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
-			{ type: "add", value: 10 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
+			{ type: "add", value: [10] },
 		]);
 	});
 
@@ -236,9 +236,9 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
-			{ type: "add", value: 2 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
+			{ type: "add", value: [2] },
 		]);
 	});
 
@@ -289,11 +289,11 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
-			{ type: "add", value: 2 },
-			{ type: "add", value: 3 },
-			{ type: "remove", value: 1 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
+			{ type: "add", value: [2] },
+			{ type: "add", value: [3] },
+			{ type: "remove", value: [1] },
 		]);
 	});
 
@@ -344,10 +344,10 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "remove", value: 1 },
-			{ type: "add", value: 3 },
-			{ type: "add", value: 2 },
+			{ type: "add", value: [1] },
+			{ type: "remove", value: [1] },
+			{ type: "add", value: [3] },
+			{ type: "add", value: [2] },
 		]);
 	});
 
@@ -379,9 +379,9 @@ describe("HashGraph for AddWinSet tests", () => {
 
 		const linearOps = obj1.hashGraph.linearizeOperations();
 		expect(linearOps).toEqual([
-			{ type: "add", value: 1 },
-			{ type: "add", value: 2 },
-			{ type: "remove", value: 2 },
+			{ type: "add", value: [1] },
+			{ type: "add", value: [2] },
+			{ type: "remove", value: [2] },
 		]);
 	});
 });
@@ -409,7 +409,7 @@ describe("HashGraph for undefined operations tests", () => {
 
 		const linearOps = obj2.hashGraph.linearizeOperations();
 		// Should only have one, since we skipped the undefined operations
-		expect(linearOps).toEqual([{ type: "add", value: 2 }]);
+		expect(linearOps).toEqual([{ type: "add", value: [2] }]);
 	});
 
 	test("Test: addToFrontier with undefined operation return Vertex with NoOp operation", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,10 +54,10 @@ importers:
   examples/canvas:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -76,10 +76,10 @@ importers:
   examples/chat:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -98,10 +98,10 @@ importers:
   examples/grid:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/node
       '@ts-drp/object':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/object
     devDependencies:
       '@types/node':
@@ -120,7 +120,7 @@ importers:
   examples/local-bootstrap:
     dependencies:
       '@ts-drp/node':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../../packages/node
     devDependencies:
       '@types/node':
@@ -143,7 +143,7 @@ importers:
         version: 4.1.5
     devDependencies:
       '@ts-drp/object':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../object
 
   packages/logger:
@@ -209,7 +209,7 @@ importers:
         specifier: ^12.3.1
         version: 12.3.4
       '@ts-drp/logger':
-        specifier: ^0.5.2
+        specifier: ^0.5.3
         version: link:../logger
       it-length-prefixed:
         specifier: ^9.1.0
@@ -249,16 +249,16 @@ importers:
         specifier: ^2.1.3
         version: 2.3.0
       '@ts-drp/blueprints':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../blueprints
       '@ts-drp/logger':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../logger
       '@ts-drp/network':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../network
       '@ts-drp/object':
-        specifier: 0.5.2
+        specifier: 0.5.3
         version: link:../object
       commander:
         specifier: ^13.0.0
@@ -289,7 +289,7 @@ importers:
   packages/object:
     dependencies:
       '@ts-drp/logger':
-        specifier: ^0.5.2
+        specifier: ^0.5.3
         version: link:../logger
       es-toolkit:
         specifier: 1.30.1


### PR DESCRIPTION
Update proxyHandler to make sure the `operation.value` to always be an array, simplifying handling and ensuring consistency. 
Relevant type definitions and tests have been updated to reflect this change.
Resolve #354 