### PR TITLE
fix: Updates Both DRP State and ACL State Incorrectly

### DIFF
--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -215,7 +215,14 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 		});
 		this.hashGraph.addToFrontier(vertex);
 
-		this._setState(vertex, this._getDRPState(drp));
+		const preCompute = this.computeLCA(vertex.dependencies);
+		if (drpType === DrpType.DRP) {
+			this._setObjectACLState(vertex, preCompute);
+			this._setDRPState(vertex, preCompute, this._getDRPState(drp));
+		} else {
+			this._setObjectACLState(vertex, preCompute, this._getDRPState(drp));
+			this._setDRPState(vertex, preCompute);
+		}
 		this._initializeFinalityState(vertex.hash);
 
 		this.vertices.push(vertex);
@@ -493,13 +500,6 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 	): ObjectPb.DRPState {
 		const acl = this._computeObjectACL(vertexDependencies, preCompute, vertexOperation);
 		return this._getDRPState(acl);
-	}
-
-	// store the state of the DRP corresponding to the given vertex
-	private _setState(vertex: Vertex, drpState?: ObjectPb.DRPState) {
-		const preCompute = this.computeLCA(vertex.dependencies);
-		this._setObjectACLState(vertex, preCompute, drpState);
-		this._setDRPState(vertex, preCompute, drpState);
 	}
 
 	private _setObjectACLState(

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -215,13 +215,12 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 		});
 		this.hashGraph.addToFrontier(vertex);
 
-		const preCompute = this.computeLCA(vertex.dependencies);
 		if (drpType === DrpType.DRP) {
-			this._setObjectACLState(vertex, preCompute);
-			this._setDRPState(vertex, preCompute, this._getDRPState(drp));
+			this._setObjectACLState(vertex, undefined);
+			this._setDRPState(vertex, undefined, this._getDRPState(drp));
 		} else {
-			this._setObjectACLState(vertex, preCompute, this._getDRPState(drp));
-			this._setDRPState(vertex, preCompute);
+			this._setObjectACLState(vertex, undefined, this._getDRPState(drp));
+			this._setDRPState(vertex, undefined);
 		}
 		this._initializeFinalityState(vertex.hash);
 

--- a/packages/object/tests/drpobject.test.ts
+++ b/packages/object/tests/drpobject.test.ts
@@ -1,6 +1,15 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { SetDRP } from "@ts-drp/blueprints/src/index.js";
+import { beforeEach, describe, expect, it, test } from "vitest";
 
-import { DRPObject } from "../src/index.js";
+import { DRPObject, ObjectACL } from "../src/index.js";
+
+const acl = new ObjectACL({
+	admins: new Map([
+		["peer1", { ed25519PublicKey: "pubKey1", blsPublicKey: "pubKey1" }],
+		["peer2", { ed25519PublicKey: "pubKey2", blsPublicKey: "pubKey2" }],
+		["peer3", { ed25519PublicKey: "pubKey3", blsPublicKey: "pubKey3" }],
+	]),
+});
 
 describe("AccessControl tests with RevokeWins resolution", () => {
 	beforeEach(() => {});
@@ -23,5 +32,43 @@ describe("AccessControl tests with RevokeWins resolution", () => {
 	test("Test creating an object wo/ DRP", () => {
 		const obj = DRPObject.createObject({ peerId: "" });
 		expect(obj.drp).toBeUndefined();
+	});
+});
+
+describe("Drp Object should be able to change state value", () => {
+	let drpObject: DRPObject;
+
+	beforeEach(async () => {
+		drpObject = new DRPObject({ peerId: "peer1", acl, drp: new SetDRP<number>() });
+	});
+
+	it("should update ACL state keys when DRP state changes", () => {
+		const drpSet = drpObject.drp as SetDRP<number>;
+		const aclInstance = drpObject.acl as ObjectACL;
+
+		// Add a value to the DRP set
+		drpSet.add(1);
+
+		// Get the ACL states and expected variable names
+		const aclStates = drpObject.aclStates.values();
+		const expectedKeys = Object.keys(aclInstance);
+
+		// Check that each state contains the expected keys
+		for (const state of aclStates) {
+			const stateKeys = state.state.map((x) => x.key);
+			expect(stateKeys).toEqual(expectedKeys);
+		}
+
+		const drpStates = drpObject.drpStates.values();
+		const expectedDrpKeys = Object.keys(drpSet);
+
+		// Check that each state contains the expected keys
+		for (const state of drpStates) {
+			if (state.state.length === 0) {
+				continue;
+			}
+			const stateKeys = state.state.map((x) => x.key);
+			expect(stateKeys).toEqual(expectedDrpKeys);
+		}
 	});
 });

--- a/packages/object/tests/drpobject.test.ts
+++ b/packages/object/tests/drpobject.test.ts
@@ -64,9 +64,6 @@ describe("Drp Object should be able to change state value", () => {
 
 		// Check that each state contains the expected keys
 		for (const state of drpStates) {
-			if (state.state.length === 0) {
-				continue;
-			}
 			const stateKeys = state.state.map((x) => x.key);
 			expect(stateKeys).toEqual(expectedDrpKeys);
 		}


### PR DESCRIPTION
to close bug #429 
- fix error when `callFn` update again state of DRP and ACL