### PR TITLE
improv: use only new vertices for hashgraph merging

### DIFF
--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -240,6 +240,7 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 	 */
 	private _mergeWithDrp(vertices: Vertex[]): [merged: boolean, missing: string[]] {
 		const missing: Hash[] = [];
+		const newVertices: Vertex[] = this.vertices;
 		for (const vertex of vertices) {
 			// Check to avoid manually crafted `undefined` operations
 			if (!vertex.operation || this.hashGraph.vertices.has(vertex.hash)) {
@@ -275,13 +276,12 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 					this._setDRPState(vertex, preComputeLca);
 				}
 				this._initializeFinalityState(vertex.hash);
+				newVertices.push(vertex);
 			} catch (_) {
 				missing.push(vertex.hash);
 			}
 		}
 
-		this.vertices = this.hashGraph.getAllVertices();
-		const newVertices = this.vertices.filter((v) => !missing.includes(v.hash));
 		this._updateObjectACLState();
 		this._updateDRPState();
 		this._notify("merge", newVertices);

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -239,7 +239,7 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 	/* Merges the vertices into the hashgraph using DRP
 	 */
 	private _mergeWithDrp(vertices: Vertex[]): [merged: boolean, missing: string[]] {
-		const missing: string[] = [];
+		const missing: Hash[] = [];
 		for (const vertex of vertices) {
 			// Check to avoid manually crafted `undefined` operations
 			if (!vertex.operation || this.hashGraph.vertices.has(vertex.hash)) {

--- a/packages/object/src/index.ts
+++ b/packages/object/src/index.ts
@@ -239,7 +239,7 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 	/* Merges the vertices into the hashgraph using DRP
 	 */
 	private _mergeWithDrp(vertices: Vertex[]): [merged: boolean, missing: string[]] {
-		const missing = [];
+		const missing: string[] = [];
 		for (const vertex of vertices) {
 			// Check to avoid manually crafted `undefined` operations
 			if (!vertex.operation || this.hashGraph.vertices.has(vertex.hash)) {
@@ -281,9 +281,10 @@ export class DRPObject implements ObjectPb.DRPObjectBase {
 		}
 
 		this.vertices = this.hashGraph.getAllVertices();
+		const newVertices = this.vertices.filter((v) => !missing.includes(v.hash));
 		this._updateObjectACLState();
 		this._updateDRPState();
-		this._notify("merge", this.vertices);
+		this._notify("merge", newVertices);
 
 		return [missing.length === 0, missing];
 	}


### PR DESCRIPTION
resolves #420 